### PR TITLE
add a gitignore to not push credentials by mistake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+*outputs*


### PR DESCRIPTION
Since in the docs we're supposed to add some credentials in the "outputs" files, I think adding a gitignore could be a good idea